### PR TITLE
Fix useless requirement of ConsoleNoLogin config

### DIFF
--- a/src/RunTracy/Middlewares/TracyMiddleware.php
+++ b/src/RunTracy/Middlewares/TracyMiddleware.php
@@ -126,7 +126,7 @@ class TracyMiddleware
             Debugger::getBar()->addPanel(new \RunTracy\Helpers\IncludedFiles());
         }
         // check if enabled or blink if active critical value
-        if (isset($cfg['showConsolePanel']) || $this->defcfg['configs']['ConsoleNoLogin']) {
+        if (isset($cfg['showConsolePanel']) || (isset($cfg['configs']['ConsoleNoLogin']) && $this->defcfg['configs']['ConsoleNoLogin'])) {
             Debugger::getBar()->addPanel(new \RunTracy\Helpers\ConsolePanel(
                 $this->defcfg['configs']
             ));


### PR DESCRIPTION
Even when the Console Panel is not enable by settings (i.e. the entry is not present), the `ConsoleNoLogin` config is required.
It make no sense to force definition of this config if the panel is not going to be used.

```
PHP Notice: Undefined index: ConsoleNoLogin in /var/www/glpi/vendor/runcmf/runtracy/src/RunTracy/Middlewares/TracyMiddleware.php at line 129
```